### PR TITLE
Changes per discussion on 9/14

### DIFF
--- a/development/d-acts.owl
+++ b/development/d-acts.owl
@@ -31,10 +31,10 @@ However, there are some amendments from our side which are to be found in the do
         <dc:creator>Mauricio B. Almeida</dc:creator>
         <dc:title xml:lang="en">document act ontology</dc:title>
     </owl:Ontology>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Object Properties
@@ -42,7 +42,7 @@ However, there are some amendments from our side which are to be found in the do
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/BFO_0000054 -->
@@ -61,7 +61,7 @@ However, there are some amendments from our side which are to be found in the do
         <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">realized in</rdfs:label>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/BFO_0000055 -->
@@ -70,7 +70,7 @@ However, there are some amendments from our side which are to be found in the do
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:label xml:lang="en">realizes</rdfs:label>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021011 -->
@@ -87,7 +87,7 @@ It is important to note that this going out of existence of s is complete and un
         <obo:IAO_0000117>Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">legally revokes</rdfs:label>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021012 -->
@@ -103,30 +103,8 @@ It is important to note that this going out of existence of s is complete and un
         <rdfs:label xml:lang="en">obsolete_legally transfers</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
+
     
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000293 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000293">
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000299 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000299">
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000312 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000312"/>
-    
-
 
     <!-- http://purl.obolibrary.org/obo/OMRSE_00000020 -->
 
@@ -138,7 +116,7 @@ It is important to note that this going out of existence of s is complete and un
         <rdfs:label>is-aggregate-of</rdfs:label>
         <owl:deprecated xml:lang="en">true</owl:deprecated>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/RO_0002218 -->
@@ -155,10 +133,10 @@ It is important to note that this going out of existence of s is complete and un
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/ro/subsets#ro-eco"/>
         <rdfs:label xml:lang="en">has active participant</rdfs:label>
     </owl:ObjectProperty>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Classes
@@ -166,7 +144,7 @@ It is important to note that this going out of existence of s is complete and un
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
+
 
 
     <!-- http://purl.obolibary.org/obo/IAO_0021001 -->
@@ -193,7 +171,7 @@ It is important to note that this going out of existence of s is complete and un
         <obo:IAO_0000117>Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">deontic document act</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0020021 -->
@@ -252,7 +230,7 @@ It is important to note that this going out of existence of s is complete and un
         <obo:IAO_0000117>Amanda Hicks</obo:IAO_0000117>
         <rdfs:label xml:lang="en">identity document</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0020022 -->
@@ -287,7 +265,7 @@ It is important to note that this going out of existence of s is complete and un
 Is part_of the appropriate relation to use for data items and documented identities?</rdfs:comment>
         <rdfs:label xml:lang="en">documented identity</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0020023 -->
@@ -328,7 +306,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117>Amanda Hicks</obo:IAO_0000117>
         <rdfs:label xml:lang="en">authentication</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0020024 -->
@@ -364,7 +342,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117 xml:lang="en">Amanda Hicks</obo:IAO_0000117>
         <rdfs:label xml:lang="en">credential role</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021000 -->
@@ -375,7 +353,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_claim</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021001 -->
@@ -386,7 +364,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_obligation</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021002 -->
@@ -401,7 +379,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obolete_document act</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021003 -->
@@ -413,7 +391,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117>Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">social act</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021004 -->
@@ -426,7 +404,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_socio-legal generically dependent continuant</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021005 -->
@@ -443,7 +421,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_deontic declaration</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021006 -->
@@ -454,7 +432,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">obligee role</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021007 -->
@@ -465,7 +443,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">document act input document</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021008 -->
@@ -477,7 +455,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117 xml:lang="en">Neil Otte</obo:IAO_0000117>
         <rdfs:label xml:lang="en">deontic role</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021009 -->
@@ -502,7 +480,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117>Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">deontic declaration</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021014 -->
@@ -515,7 +493,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_declaration executive role</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021015 -->
@@ -530,7 +508,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_document template creator role</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021017 -->
@@ -543,7 +521,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_claimant role</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021018 -->
@@ -556,7 +534,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_obligator role</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021020 -->
@@ -570,7 +548,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_declaration target</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021021 -->
@@ -625,7 +603,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117>Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">document act template creator role</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021022 -->
@@ -637,7 +615,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000118 xml:lang="en">declaration performer role</obo:IAO_0000118>
         <rdfs:label xml:lang="en">deontic declaration performer role</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021030 -->
@@ -649,7 +627,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsoleted_document act target</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021031 -->
@@ -684,7 +662,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">document act performer role</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021102 -->
@@ -696,7 +674,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000118 xml:lang="en">enactment</obo:IAO_0000118>
         <rdfs:label xml:lang="en">standing declaration</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021300 -->
@@ -708,7 +686,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">obligor role</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_9606 -->
@@ -720,7 +698,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
         <rdfs:label xml:lang="en">Homo sapiens</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/OBI_0000245 -->
@@ -765,7 +743,7 @@ for now.</obo:IAO_0000116>
         <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GROUP: OBI</obo:IAO_0000119>
         <rdfs:label xml:lang="en">organization</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/OBI_0100026 -->
@@ -786,7 +764,7 @@ This issue is outside the scope of OBI.</obo:IAO_0000116>
         <obo:IAO_0000119 xml:lang="en">WEB: http://en.wikipedia.org/wiki/Organism</obo:IAO_0000119>
         <rdfs:label xml:lang="en">organism</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/OMRSE_00000022 -->
@@ -803,7 +781,7 @@ This issue is outside the scope of OBI.</obo:IAO_0000116>
         <rdfs:comment xml:lang="en">Any arbitrary collection of organisms.  They need not be of the same taxonomic class.  </rdfs:comment>
         <rdfs:label xml:lang="en">collection of organisms</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/OMRSE_00000023 -->
@@ -819,7 +797,7 @@ This issue is outside the scope of OBI.</obo:IAO_0000116>
         <rdfs:comment xml:lang="en">An object aggregate all of whose components are human beings.</rdfs:comment>
         <rdfs:label xml:lang="en">collection of humans</rdfs:label>
     </owl:Class>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/OMRSE_00000033 -->
@@ -842,4 +820,3 @@ This issue is outside the scope of OBI.</obo:IAO_0000116>
 
 
 <!-- Generated by the OWL API (version 4.2.8.20170104-2310) https://github.com/owlcs/owlapi -->
-

--- a/development/d-acts.owl
+++ b/development/d-acts.owl
@@ -2,6 +2,7 @@
 <rdf:RDF xmlns="http://purl.obolibrary.org/obo/iao/d-acts/dev/d-acts.owl/"
      xml:base="http://purl.obolibrary.org/obo/iao/d-acts/dev/d-acts.owl/"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:terms="http://purl.org/dc/terms/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
@@ -10,13 +11,12 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:foaf="http://xmlns.com/foaf/0.1/"
-     xmlns:terms="http://purl.org/dc/terms/"
      xmlns:dc="http://purl.org/dc/elements/1.1/">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/iao/d-acts/dev/d-acts.owl">
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/iao/pno.owl"/>
         <dc:license rdf:resource="http://creativecommons.org/licenses/by/3.0/"/>
-        <terms:license xml:lang="en">http://creativecommons.org/licenses/by/3.0/</terms:license>
         <obo:IAO_0000597 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IAO_0021000-IAO_0021999</obo:IAO_0000597>
+        <terms:license xml:lang="en">http://creativecommons.org/licenses/by/3.0/</terms:license>
         <dc:creator>Mathias Brochhausen</dc:creator>
         <owl:versionInfo>development version 2018-08-09</owl:versionInfo>
         <dc:description xml:lang="en">The ontology is based on a theory of document acts proposed by Barry Smith and Reinach&apos;s theory of social acts and legal entities:
@@ -33,10 +33,10 @@ However, there are some amendments from our side which are to be found in the do
         <dc:creator>Mauricio B. Almeida</dc:creator>
         <dc:title xml:lang="en">document act ontology</dc:title>
     </owl:Ontology>
+    
 
 
-
-    <!--
+    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Object Properties
@@ -44,7 +44,7 @@ However, there are some amendments from our side which are to be found in the do
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/BFO_0000054 -->
@@ -63,7 +63,7 @@ However, there are some amendments from our side which are to be found in the do
         <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">realized in</rdfs:label>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/BFO_0000055 -->
@@ -72,7 +72,7 @@ However, there are some amendments from our side which are to be found in the do
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:label xml:lang="en">realizes</rdfs:label>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021011 -->
@@ -89,7 +89,7 @@ It is important to note that this going out of existence of s is complete and un
         <obo:IAO_0000117>Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">legally revokes</rdfs:label>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021012 -->
@@ -105,7 +105,7 @@ It is important to note that this going out of existence of s is complete and un
         <rdfs:label xml:lang="en">obsolete_legally transfers</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/OMRSE_00000020 -->
@@ -117,7 +117,7 @@ It is important to note that this going out of existence of s is complete and un
 </rdfs:comment>
         <rdfs:label>is-aggregate-of</rdfs:label>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/RO_0002218 -->
@@ -134,10 +134,10 @@ It is important to note that this going out of existence of s is complete and un
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/ro/subsets#ro-eco"/>
         <rdfs:label xml:lang="en">has active participant</rdfs:label>
     </owl:ObjectProperty>
+    
 
 
-
-    <!--
+    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Classes
@@ -145,7 +145,7 @@ It is important to note that this going out of existence of s is complete and un
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-
+    
 
 
     <!-- http://purl.obolibary.org/obo/IAO_0021001 -->
@@ -172,7 +172,7 @@ It is important to note that this going out of existence of s is complete and un
         <obo:IAO_0000117>Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">deontic document act</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0020021 -->
@@ -231,7 +231,7 @@ It is important to note that this going out of existence of s is complete and un
         <obo:IAO_0000117>Amanda Hicks</obo:IAO_0000117>
         <rdfs:label xml:lang="en">identity document</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0020022 -->
@@ -266,7 +266,7 @@ It is important to note that this going out of existence of s is complete and un
 Is part_of the appropriate relation to use for data items and documented identities?</rdfs:comment>
         <rdfs:label xml:lang="en">documented identity</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0020023 -->
@@ -307,7 +307,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117>Amanda Hicks</obo:IAO_0000117>
         <rdfs:label xml:lang="en">authentication</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0020024 -->
@@ -343,7 +343,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117 xml:lang="en">Amanda Hicks</obo:IAO_0000117>
         <rdfs:label xml:lang="en">credential role</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021000 -->
@@ -354,18 +354,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_claim</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0021001 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0021001">
-        <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
-        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
-        <rdfs:label xml:lang="en">obsolete_obligation</rdfs:label>
-        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
-    </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021002 -->
@@ -380,7 +369,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_document act</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021003 -->
@@ -392,7 +381,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117>Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">social act</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021004 -->
@@ -405,7 +394,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_socio-legal generically dependent continuant</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021005 -->
@@ -422,7 +411,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_deontic declaration</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021006 -->
@@ -433,7 +422,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">obligee role</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021007 -->
@@ -444,7 +433,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">document act input document</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021008 -->
@@ -456,7 +445,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117 xml:lang="en">Neil Otte</obo:IAO_0000117>
         <rdfs:label xml:lang="en">deontic role</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021009 -->
@@ -481,7 +470,18 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117>Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">deontic declaration</rdfs:label>
     </owl:Class>
+    
 
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0021010 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0021010">
+        <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label xml:lang="en">obsolete_obligation</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </owl:Class>
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021014 -->
@@ -494,7 +494,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_declaration executive role</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021015 -->
@@ -509,7 +509,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_document template creator role</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021017 -->
@@ -522,7 +522,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_claimant role</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021018 -->
@@ -535,7 +535,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_obligator role</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021020 -->
@@ -549,7 +549,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsolete_declaration target</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021021 -->
@@ -584,7 +584,7 @@ Is part_of the appropriate relation to use for data items and documented identit
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000310"/>
                                                             <owl:Restriction>
                                                                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000056"/>
-                                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/IAO_0021002"/>
+                                                                <owl:someValuesFrom rdf:resource="http://purl.obolibary.org/obo/IAO_0021001"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
                                                     </owl:Class>
@@ -604,7 +604,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117>Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">document act template creator role</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021022 -->
@@ -616,7 +616,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000118 xml:lang="en">declaration performer role</obo:IAO_0000118>
         <rdfs:label xml:lang="en">deontic declaration performer role</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021030 -->
@@ -628,7 +628,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <rdfs:label xml:lang="en">obsoleted_document act target</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021031 -->
@@ -663,7 +663,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">document act performer role</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021102 -->
@@ -675,7 +675,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000118 xml:lang="en">enactment</obo:IAO_0000118>
         <rdfs:label xml:lang="en">standing declaration</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0021300 -->
@@ -687,7 +687,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">obligor role</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_9606 -->
@@ -699,7 +699,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
         <rdfs:label xml:lang="en">Homo sapiens</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/OBI_0000245 -->
@@ -744,7 +744,7 @@ for now.</obo:IAO_0000116>
         <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GROUP: OBI</obo:IAO_0000119>
         <rdfs:label xml:lang="en">organization</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/OBI_0100026 -->
@@ -765,7 +765,7 @@ This issue is outside the scope of OBI.</obo:IAO_0000116>
         <obo:IAO_0000119 xml:lang="en">WEB: http://en.wikipedia.org/wiki/Organism</obo:IAO_0000119>
         <rdfs:label xml:lang="en">organism</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/OMRSE_00000022 -->
@@ -782,7 +782,7 @@ This issue is outside the scope of OBI.</obo:IAO_0000116>
         <rdfs:comment xml:lang="en">Any arbitrary collection of organisms.  They need not be of the same taxonomic class.  </rdfs:comment>
         <rdfs:label xml:lang="en">collection of organisms</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/OMRSE_00000023 -->
@@ -798,7 +798,7 @@ This issue is outside the scope of OBI.</obo:IAO_0000116>
         <rdfs:comment xml:lang="en">An object aggregate all of whose components are human beings.</rdfs:comment>
         <rdfs:label xml:lang="en">collection of humans</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/OMRSE_00000033 -->
@@ -821,3 +821,4 @@ This issue is outside the scope of OBI.</obo:IAO_0000116>
 
 
 <!-- Generated by the OWL API (version 4.2.8.20170104-2310) https://github.com/owlcs/owlapi -->
+

--- a/development/d-acts.owl
+++ b/development/d-acts.owl
@@ -227,7 +227,7 @@ It is important to note that this going out of existence of s is complete and un
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <obo:IAO_0000115 xml:lang="en">a document that denotes some identity and is concretized by the bearer of some credential role</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A document that denotes some identity and is concretized by the bearer of some credential role.</obo:IAO_0000115>
         <obo:IAO_0000117>Amanda Hicks</obo:IAO_0000117>
         <rdfs:label xml:lang="en">identity document</rdfs:label>
     </owl:Class>
@@ -260,7 +260,7 @@ It is important to note that this going out of existence of s is complete and un
                 </owl:intersectionOf>
             </owl:Class>
         </rdfs:subClassOf>
-        <obo:IAO_0000115 xml:lang="en">a documented identity is the aggregate of all data items about an entity.  Notice that a documented identity is not itself a document since a document is intended to be understood as a whole and data items about an individual are usually scattered across different documents.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A documented identity is the aggregate of all data items about an entity.  Notice that a documented identity is not itself a document since a document is intended to be understood as a whole and data items about an individual are usually scattered across different documents.</obo:IAO_0000115>
         <obo:IAO_0000117>Amanda Hicks</obo:IAO_0000117>
         <rdfs:comment xml:lang="en">is an aggregate of ICEs also an ICE? yes
 Is part_of the appropriate relation to use for data items and documented identities?</rdfs:comment>
@@ -339,7 +339,7 @@ Is part_of the appropriate relation to use for data items and documented identit
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
-        <obo:IAO_0000115 xml:lang="en"> a role that inheres in a concretization of an identity document and is realized by an authentication process</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A role that inheres in a concretization of an identity document and is realized by an authentication process.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Amanda Hicks</obo:IAO_0000117>
         <rdfs:label xml:lang="en">credential role</rdfs:label>
     </owl:Class>

--- a/development/d-acts.owl
+++ b/development/d-acts.owl
@@ -653,7 +653,7 @@ Is part_of the appropriate relation to use for data items and documented identit
                     </owl:Restriction>
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000054"/>
-                        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/IAO_0021002"/>
+                        <owl:allValuesFrom rdf:resource="http://purl.obolibary.org/obo/IAO_0021001"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>

--- a/development/d-acts.owl
+++ b/development/d-acts.owl
@@ -37,110 +37,6 @@ However, there are some amendments from our side which are to be found in the do
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
-    // Annotation properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000111 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000111">
-        <rdfs:label xml:lang="en">editor preferred term</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000112 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000112">
-        <rdfs:label xml:lang="en">example of usage</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000114 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000114">
-        <rdfs:label xml:lang="en">has curation status</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
-        <rdfs:label xml:lang="en">definition</rdfs:label>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definition</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116">
-        <rdfs:label xml:lang="en">editor note</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000117 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117">
-        <rdfs:label xml:lang="en">term editor</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000118 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118">
-        <rdfs:label xml:lang="en">alternative term</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000119 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000231 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000231"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000412 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
-        <rdfs:label xml:lang="en">imported from</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000600 -->
-
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000600">
-        <rdfs:label xml:lang="en">elucidation</rdfs:label>
-    </rdf:Description>
-    
-
-
-    <!-- http://www.geneontology.org/formats/oboInOwl#inSubset -->
-
-    <rdf:Description rdf:about="http://www.geneontology.org/formats/oboInOwl#inSubset">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">in_subset</rdfs:label>
-    </rdf:Description>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
     // Object Properties
     //
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -565,7 +461,7 @@ Is part_of the appropriate relation to use for data items and documented identit
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0021007">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000310"/>
-        <obo:IAO_0000117 xml:lang="en">A document that is intended to be the specified input in a document act. It has a plan specification as a part that specifies the intended socio-legal entities that are created through the document (objective specification) and the way in which the document act is to be performed (by signing, by stamping, etc.) (action specification).</obo:IAO_0000117>
+        <obo:IAO_0000115 xml:lang="en">A document that is intended to be the specified input in a document act. It has a plan specification as a part that specifies the intended socio-legal entities that are created through the document (objective specification) and the way in which the document act is to be performed (by signing, by stamping, etc.) (action specification).</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">document act input document</rdfs:label>
     </owl:Class>

--- a/development/d-acts.owl
+++ b/development/d-acts.owl
@@ -10,14 +10,16 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:terms="http://purl.org/dc/terms/"
      xmlns:dc="http://purl.org/dc/elements/1.1/">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/iao/d-acts/dev/d-acts.owl">
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/iao/pno.owl"/>
         <dc:license rdf:resource="http://creativecommons.org/licenses/by/3.0/"/>
+        <terms:license xml:lang="en">http://creativecommons.org/licenses/by/3.0/</terms:license>
         <obo:IAO_0000597 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IAO_0021000-IAO_0021999</obo:IAO_0000597>
         <dc:creator>Mathias Brochhausen</dc:creator>
         <owl:versionInfo>development version 2018-08-09</owl:versionInfo>
-        <rdfs:comment xml:lang="en">The ontology is based on a theory of document acts proposed by Barry Smith and Reinach&apos;s theory of social acts and legal entities:
+        <dc:description xml:lang="en">The ontology is based on a theory of document acts proposed by Barry Smith and Reinach&apos;s theory of social acts and legal entities:
 
 Reinach, A. (1989), Sämtliche Werke. Texkritische Ausgabe, Edited by Karl Schuhmann and Barry Smith, München: Philosophia Verlag.
 
@@ -25,7 +27,7 @@ Smith, B. (2008) “Searle and de Soto: The new ontology of the social world”,
 
 Smith, B. (2012) &quot;How to Do Things With Documents&quot;, Rivista di estetica, 50 (2/2012), LII: 179-198.
 
-However, there are some amendments from our side which are to be found in the documentation.</rdfs:comment>
+However, there are some amendments from our side which are to be found in the documentation.</dc:description>
         <dc:creator>Laura Slaughter</dc:creator>
         <dc:creator>Amanda Hicks</dc:creator>
         <dc:creator>Mauricio B. Almeida</dc:creator>
@@ -104,7 +106,7 @@ It is important to note that this going out of existence of s is complete and un
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
 
-    
+
 
     <!-- http://purl.obolibrary.org/obo/OMRSE_00000020 -->
 
@@ -114,7 +116,6 @@ It is important to note that this going out of existence of s is complete and un
         <rdfs:comment xml:lang="en">We anticipate BFO 2.0 including and defining this relation.  When it does, we will obsolete this property and declare it equivalent to the BFO 2.0 relation.
 </rdfs:comment>
         <rdfs:label>is-aggregate-of</rdfs:label>
-        <owl:deprecated xml:lang="en">true</owl:deprecated>
     </owl:ObjectProperty>
 
 
@@ -376,7 +377,7 @@ Is part_of the appropriate relation to use for data items and documented identit
         <obo:IAO_0000117>Mathias Brochhausen</obo:IAO_0000117>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
         <obo:IAO_0100001 rdf:resource="http://purl.obolibary.org/obo/IAO_0021001"/>
-        <rdfs:label xml:lang="en">obolete_document act</rdfs:label>
+        <rdfs:label xml:lang="en">obsolete_document act</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
 

--- a/development/d-acts.owl
+++ b/development/d-acts.owl
@@ -427,7 +427,7 @@ Is part_of the appropriate relation to use for data items and documented identit
             </owl:Class>
         </rdfs:subClassOf>
         <obo:IAO_0000112> I order a beer and the bartender authenticates my age by looking at my DOB on my driver&apos;s license.  I sign into my email account, and the system authenticates my permission to read the email by checking the password I enter against my password listed in the database.</obo:IAO_0000112>
-        <obo:IAO_0000115 xml:lang="en">Authentication is the act of checking or verifying an identity claim (that is either tacit or explicit). 
+        <obo:IAO_0000115 xml:lang="en">Authentication is the act of checking or verifying an identity claim (that is either tacit or explicit).
 </obo:IAO_0000115>
         <obo:IAO_0000117>Amanda Hicks</obo:IAO_0000117>
         <rdfs:label xml:lang="en">authentication</rdfs:label>
@@ -576,6 +576,9 @@ Is part_of the appropriate relation to use for data items and documented identit
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0021008">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
+        <obo:IAO_0000115 xml:lang="en">A role that inheres in an agent and which is externally grounded in the normative expectations that other agents within a social context have concerning how that agent should behave.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Neil Otte</obo:IAO_0000117>
         <rdfs:label xml:lang="en">deontic role</rdfs:label>
     </owl:Class>
     
@@ -586,24 +589,16 @@ Is part_of the appropriate relation to use for data items and documented identit
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0021009">
         <owl:equivalentClass>
             <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0021011"/>
-                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/IAO_0021008"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000299"/>
-                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/IAO_0021008"/>
-                            </owl:Restriction>
-                        </owl:unionOf>
-                    </owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000055"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/IAO_0021022"/>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0021011"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/IAO_0021008"/>
                     </owl:Restriction>
-                </owl:intersectionOf>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000299"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/IAO_0021008"/>
+                    </owl:Restriction>
+                </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0021003"/>
@@ -799,8 +794,8 @@ Is part_of the appropriate relation to use for data items and documented identit
     <!-- http://purl.obolibrary.org/obo/IAO_0021102 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0021102">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0021009"/>
-        <obo:IAO_0000115 xml:lang="en">A deontic declaration that postulates a socio-legal fact for a specified group of people or organizations.</obo:IAO_0000115>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0021003"/>
+        <obo:IAO_0000115 xml:lang="en">A social act that postulates a socio-legal fact for a specified group of people or organizations.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">enactment</obo:IAO_0000118>
         <rdfs:label xml:lang="en">standing declaration</rdfs:label>
@@ -946,12 +941,6 @@ This issue is outside the scope of OBI.</obo:IAO_0000116>
         <rdfs:comment xml:lang="en">It is often convenient to group organizations together that otherwise might not even interact with one another. </rdfs:comment>
         <rdfs:label xml:lang="en">aggregate of organizations</rdfs:label>
     </owl:Class>
-    
-
-
-    <!-- http://www.geneontology.org/formats/oboInOwl#ObsoleteClass -->
-
-    <owl:Class rdf:about="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
 </rdf:RDF>
 
 


### PR DESCRIPTION
This commit reflects the changes discussed on 9/14:

1. Add definition for 'deontic role.'
1. Make 'standing declaration' a subclass of 'social act.'
1. Make equivalence axiom for 'deontic declaration' less restrictive. 

Additionally, removed 'ObsoleteClass' from active ontology. 